### PR TITLE
Refactor Schema and Index Creation Logic — Split Tables vs. Indexes

### DIFF
--- a/mosaic_builder/cli.py
+++ b/mosaic_builder/cli.py
@@ -124,12 +124,15 @@ def reset_db(
     s = open_store(store)
     try:
         if mode == "wipe":
-            s.wipe_all()
-            typer.echo("[mosaic-builder] Database wiped (rows deleted, schema kept).")
+            s.wipe_all()  # 1) clear data first
+            s.ensure_schema()  # 2) make sure tables exist
+            s.ensure_indexes()  # 3) (re)create indexes now that data is clean
+            typer.echo("[mosaic-builder] Database wiped (rows deleted), schema & indexes ensured.")
         elif mode == "drop":
             s.drop_all()
             s.ensure_schema()
-            typer.echo("[mosaic-builder] Database dropped and recreated.")
+            s.ensure_indexes()
+            typer.echo("[mosaic-builder] Database dropped and recreated (schema + indexes).")
         else:
             raise typer.BadParameter('mode must be "wipe" or "drop"')
     finally:


### PR DESCRIPTION
### Summary of Changes

This update separates **table creation** from **index creation** in the database schema logic, improving reliability when updating or resetting the database. Key updates include:

* **`ensure_schema()`** now only sets up tables (and sequences for DuckDB), removing index creation.
* **New `ensure_indexes()`** method handles index creation separately—safe to run only after the database is clean.
* **`reset-db` command adjusted** to:

  * For **wipe** mode: delete data, recreate schema, then reapply indexes.
  * For **drop** mode: drop existing structure, recreate schema, then indexes.

This prevents `ConstraintException` errors (e.g. from duplicate rows) that previously occurred when attempting to recreate unique indexes before cleaning the database.

---

### Why This Matters

* **Idempotent reset workflows**: Now, running `reset-db --mode wipe` on a DB that already contains duplicates will succeed without error.
* **Safer schema management**: Clear separation between data structure and structural constraints boosts clarity and robustness.
* **Enhanced flexibility**: Having standalone `ensure_schema()` and `ensure_indexes()` allows easier extension (e.g. adding new indexes, sharding logic, etc.).

---

### Usage Example

```bash
# Clear existing data safely:
mosaic-builder reset-db --mode wipe -y

# Rebuild indexes only:
mosaic-builder reset-db --mode drop -y
```

Both commands now complete without unique constraint violations.
