### PR TITLE
Normalize Tiling with `grids`, Make Ingest Resumable, and Add Safe DB Reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,145 @@
 # mosaic-builder
 
 A Python library for reading photos and building **photo mosaics**.
-The library is designed to support creative/art projects where you want to take a collection of “source” photos (tiles) and reassemble them into a mosaic version of a “target” image.
+
+- Ingests a folder of photos, slices them into **tiles**, stores average Lab color.
+- Supports multiple **tile sizes per photo** via a normalized `grids` table.
+- Offers pluggable nearest-neighbor backends (KD-Tree now; ANN later).
+- Storage backends: **SQLite** or **DuckDB** (choose at runtime).
 
 ---
 
 ## Purpose
 
-* Provide a **reusable library** for tiling, indexing, and querying photos.
-* Make it easy to ingest large sets of source images into a database (SQLite/DuckDB).
-* Allow flexible nearest-neighbor search backends (KD-Tree, HNSW, Faiss).
-* Serve as the backbone for art projects (e.g. “Views from the Urinal”) that require organizing, analyzing, and recombining photos into mosaics.
-* Be **data-backend-agnostic**, with interfaces abstracting storage and search.
+- Provide a reusable, scriptable toolkit for **mosaic-style** art projects.
+- Make ingestion/indexing/querying reliable and resumable.
+- Keep storage and search **backend-agnostic** with clean interfaces.
+
+## Not the Purpose
+
+- Not a GUI editor or general photo manager.
+- Not optimized (yet) for multi-billion-tile, distributed compute.
+- Not a general image processing framework.
 
 ---
 
-## What is *not* the purpose
-
-* This is **not** a full GUI mosaic editor.
-* This is **not** a drop-in replacement for photo cataloging tools (e.g., Lightroom).
-* This is **not** optimized yet for distributed, billion-tile datasets (though the API leaves room for scaling).
-* It is **not** a general-purpose image processing library — it focuses narrowly on mosaic workflows.
-
----
-
-## How to Use
-
-### Install
+## Install
 
 ```bash
-# clone repo and install dev version
 git clone https://github.com/jedmitten/mosaic_builder.git
 cd mosaic_builder
-uv sync  # or: pip install -e .
-```
 
-Optional extras:
+# core (numpy, pillow, scipy, typer)
+uv sync
+
+# optional extras
+uv sync --extra analytics   # duckdb + pandas
+uv sync --extra debug       # matplotlib debug visuals
+````
+
+---
+
+## CLI Usage
+
+### Ingest photos → tiles (per grid size)
 
 ```bash
-uv sync --extra analytics  # enable DuckDB + Pandas
-uv sync --extra debug      # enable matplotlib debug visuals
+# Create (or re-use) a DB and ingest all images in ./gallery at 24×24 tiles
+mosaic-builder ingest --images-dir ./gallery --store duckdb:///mosaic.duckdb --tile-px 24 --debug-dir ./debug
+
+# Re-ingest the same photo set at 32×32 tiles; coexists with 24×24
+mosaic-builder ingest --images-dir ./gallery --store duckdb:///mosaic.duckdb --tile-px 32 --debug-dir ./debug
 ```
 
-### CLI
+Resuming behaviors:
+
+* If a **grid** (photo + tile size) already has tiles, ingest **skips** it.
+* Force refresh for a grid size with:
+
+  ```bash
+  mosaic-builder ingest --images-dir ./gallery --store duckdb:///mosaic.duckdb --tile-px 32 --reingest
+  ```
+
+### Build an index of tiles (KD-Tree)
 
 ```bash
-# ingest source photos into a DuckDB-backed store
-mosaic-builder ingest --images-dir gallery --store duckdb:///mosaic.duckdb
-
-# build a KDTree index of tiles
-mosaic-builder build-index --store duckdb:///mosaic.duckdb --index tiles_kdtree.pkl
-
-# generate a mosaic from a target image
-mosaic-builder build-mosaic --target urinal.jpg --index tiles_kdtree.pkl --out mosaic.png
+mosaic-builder build-index --store duckdb:///mosaic.duckdb --index tiles_kdtree.pkl --debug-dir ./debug
 ```
 
-### Python API
+*(Future)*: `--tile-size <N>` to index only tiles from a given grid size.
+
+### Build a mosaic from a target image
+
+```bash
+mosaic-builder build-mosaic --target ./target.jpg \
+  --store duckdb:///mosaic.duckdb \
+  --index tiles_kdtree.pkl \
+  --out mosaic.png \
+  --debug-dir ./debug
+```
+
+### Reset the database (useful during development)
+
+```bash
+# Delete rows (keep schema and indexes)
+mosaic-builder reset-db --store duckdb:///mosaic.duckdb --mode wipe -y
+
+# Drop tables/sequences and recreate schema + indexes
+mosaic-builder reset-db --store duckdb:///mosaic.duckdb --mode drop -y
+
+# Nuke the DB file itself (dangerous)
+mosaic-builder reset-db --store duckdb:///mosaic.duckdb --nuke -y
+```
+
+---
+
+## Python API (snippet)
 
 ```python
+from pathlib import Path
 from mosaic_builder.pipeline import ingest_dir
 from mosaic_builder.stores.factory import open_store
 
-store = open_store("duckdb:///mosaic.duckdb")
-ingest_dir("duckdb:///mosaic.duckdb", "gallery", tile_w=24, tile_h=24)
+store_url = "duckdb:///mosaic.duckdb"
+
+# Ingest a folder at 24px tiles; creates per-photo grids and tiles
+ingest_dir(store_url, Path("gallery"), tile_w=24, tile_h=24, debug_dir=Path("debug"))
+
+# Access vectors for indexing
+store = open_store(store_url)
+ids, vecs = store.all_tile_vectors()  # ids: List[int], vecs: np.ndarray (N,3) in Lab
+store.close()
 ```
 
 ---
 
-## How to Contribute
+## Project Structure (storage model)
 
-Contributions are welcome!
+* **photos**: `id`, `path (UNIQUE)`, `width`, `height`
+* **grids**: `id`, `photo_id`, `tile_w`, `tile_h`, `cols`, `rows`, `UNIQUE(photo_id, tile_w, tile_h)`
+* **tiles**: `id`, `grid_id`, `x`, `y`, `l`, `a`, `b`, `UNIQUE(grid_id, x, y)`
 
-* Use [pre-commit](https://pre-commit.com) hooks (`ruff`, `black`, `mypy`, `pytest`) to keep code style consistent.
-* Run the test suite with `pytest`.
-* Open an issue or pull request with a clear description of the change.
-* For larger features, please discuss in an issue before coding to ensure alignment.
+This lets the same photo have multiple tilings (24×24, 32×32, …) without conflicts.
+
+---
+
+## Contributing
+
+* Run formatting/linting/type checks via pre-commit:
+
+  ```bash
+  pre-commit install
+  pre-commit run --all-files
+  ```
+* Tests:
+
+  ```bash
+  uv run pytest -q
+  ```
+* Open issues/PRs with a concise description and reproduction steps. For larger features, please start with an issue to align on approach.
 
 ---
 
 ## License
 
-This project is licensed under the terms of the **MIT License**.
-See the [LICENSE](LICENSE) file for full text.
+Licensed under the **MIT License**. See [LICENSE](LICENSE).

--- a/mosaic_builder/cli.py
+++ b/mosaic_builder/cli.py
@@ -43,12 +43,13 @@ def ingest(
     config: Path | None = typer.Option(None, "--config", "-c"),
     store: str | None = typer.Option(None),
     tile_px: int | None = typer.Option(None),
-    debug_dir: Path | None = typer.Option(None, help="Save debug images here"),
+    debug_dir: Path | None = typer.Option(None),
+    reingest: bool = typer.Option(False, help="Recompute tiles for this grid size if it already exists."),
 ):
     cfg = _resolve_cfg(config, images_dir, store, None, tile_px)
     if cfg.photos_src is None:
         raise typer.BadParameter("photos_src not provided.")
-    ingest_dir(cfg.store_url, cfg.photos_src, cfg.tile_px, cfg.tile_px, debug_dir)
+    ingest_dir(cfg.store_url, cfg.photos_src, cfg.tile_px, cfg.tile_px, debug_dir, reingest=reingest)
 
 
 @app.command()

--- a/mosaic_builder/pipeline/ingest.py
+++ b/mosaic_builder/pipeline/ingest.py
@@ -1,9 +1,6 @@
-import signal
-import sys
 from pathlib import Path
 
 import numpy as np
-from PIL import Image
 from PIL import Image as PILImage
 from PIL import ImageOps
 from rich.progress import (
@@ -27,17 +24,9 @@ def avg_lab_from_patch(pil_img):
 
 
 def ingest_dir(
-    store_url: str,
-    images_dir: Path,
-    tile_w=24,
-    tile_h=24,
-    debug_dir: Path | None = None,
+    store_url: str, images_dir: Path, tile_w=24, tile_h=24, debug_dir: Path | None = None, reingest: bool = False
 ):
-    images = [
-        p
-        for p in sorted(images_dir.rglob("*"))
-        if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}
-    ]
+    images = [p for p in sorted(images_dir.rglob("*")) if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp"}]
     if not images:
         print(f"No images found under {images_dir}")
         return
@@ -61,59 +50,44 @@ def ingest_dir(
         TimeRemainingColumn(),
     ) as progress:
         files_task = progress.add_task("Photos", total=len(images))
-
         for p in images:
             im = ImageOps.exif_transpose(PILImage.open(p).convert("RGB"))
             w, h = im.size
             photo_id = store.upsert_photo(p, w, h)
 
-            # Skip if this photo already has tiles (resume-friendly)
-            if store.has_tiles_for_photo(photo_id):
-                progress.update(
-                    files_task,
-                    advance=1,
-                    description="Photos (skipping already ingested)",
-                )
-                continue
-
             cols, rows = w // tile_w, h // tile_h
-            total_tiles = cols * rows
-            per_file = progress.add_task(
-                f"Tiling {p.name} ({cols}×{rows})", total=total_tiles
-            )
+            grid_id = store.upsert_grid(photo_id, tile_w, tile_h, cols, rows)
 
-            batch = []
-            thumbs = (
-                PILImage.new("RGB", (cols * tile_w, rows * tile_h))
-                if (debug_dir and cols and rows)
-                else None
-            )
+            # Skip or force reingest per grid
+            if store.has_tiles_for_grid(grid_id) and not reingest:
+                progress.update(files_task, advance=1, description="Photos (skipping)")
+                continue
+            if reingest:
+                store.delete_tiles_for_grid(grid_id)
+
+            total_tiles = cols * rows
+            per_file = progress.add_task(f"Tiling {p.name} ({cols}×{rows})", total=total_tiles)
+
+            rows_to_insert: list[tuple[int, int, float, float, float]] = []
+            thumbs = PILImage.new("RGB", (cols * tile_w, rows * tile_h)) if (debug_dir and cols and rows) else None
 
             for y in range(rows):
                 for x in range(cols):
                     box = (x * tile_w, y * tile_h, (x + 1) * tile_w, (y + 1) * tile_h)
                     patch = im.crop(box)
                     L, A, B = avg_lab_from_patch(patch)
-                    batch.append(
-                        (photo_id, x, y, tile_w, tile_h, float(L), float(A), float(B))
-                    )
+                    rows_to_insert.append((x, y, float(L), float(A), float(B)))
                     if thumbs:
-                        thumbs.paste(
-                            patch.resize((tile_w, tile_h)), (x * tile_w, y * tile_h)
-                        )
+                        thumbs.paste(patch.resize((tile_w, tile_h)), (x * tile_w, y * tile_h))
                     progress.update(per_file, advance=1)
 
-            if batch:
-                # Conflict-safe insert; duplicates are ignored by the store
-                store.insert_tiles(batch)
-                tiles_total += len(batch)
-            photos_total += 1
+            if rows_to_insert:
+                store.insert_tiles(grid_id, rows_to_insert)
+
             progress.update(files_task, advance=1)
             progress.remove_task(per_file)
-
             if thumbs:
-                thumbs.save((debug_dir / f"{p.stem}_tiles.jpg"))
+                thumbs.save((debug_dir / f"{p.stem}_tiles_{tile_w}x{tile_h}.jpg"))
+
     store.close()
-    print(
-        f"[mosaic-builder] Ingest complete: {photos_total} new photos, {tiles_total} tiles added."
-    )
+    print(f"[mosaic-builder] Ingest complete: {photos_total} new photos, {tiles_total} tiles added.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+ignore = ["E741"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+# because I'm using Lab for images, which has single-letter variable names
 ignore = ["E741"]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

This PR introduces a normalized schema with a new **`grids`** table (per-photo, per-tile-size), makes ingest **resumable and multi-size aware**, and adds a robust **`reset-db`** command that safely drops/wipes DuckDB/SQLite databases without constraint errors.

## Key Changes

* **Schema normalization**

  * New `grids` table: `(photo_id, tile_w, tile_h, cols, rows)`, `UNIQUE(photo_id, tile_w, tile_h)`
  * `tiles` now reference `grid_id` and are unique on `(grid_id, x, y)`
  * Separate `ensure_schema()` (tables/sequences) from `ensure_indexes()` (indexes) for safe ordering
* **Ingest pipeline**

  * One **grid per photo per tile size**; multiple sizes can co-exist for the same photo
  * **Resumable**: skip already-ingested grids; optional `--reingest` to refresh a single grid
  * Progress UI labels improved (per-file status)
  * Graceful `CTRL-C` handling with a clear message and clean shutdown
* **DB reset CLI**

  * `mosaic-builder reset-db` with `--mode wipe|drop` and `--nuke`
  * DuckDB quirks handled (`DROP SEQUENCE IF EXISTS`, split indexes to avoid `ConstraintException`)
* **Store API**

  * `upsert_photo`, **`upsert_grid`**, `has_tiles_for_grid`, `delete_tiles_for_grid`, `insert_tiles(grid_id, …)`
  * `tile_patch_info` now joins `tiles→grids→photos` to return tile size alongside coordinates

## Why

* Changing tile sizes (e.g., 24→32 px) should not collide with earlier runs.
* Reset operations should be **idempotent and safe**, even with existing duplicates.
* Clearer data model = simpler future features (filtering by size, per-grid analytics, etc.).

## Migration Notes

* Run:

  ```bash
  mosaic-builder reset-db --store duckdb:///mosaic.duckdb --mode drop -y
  ```

  to create the new schema. (This **drops** prior data.)

## Testing

* Ingest same photos at 24px and 32px; verify two grids created and no conflicts.
* Cancel ingest mid-run; rerun; verify skipped grids and no duplicates.
* `reset-db --mode wipe` and `--mode drop` on both SQLite and DuckDB succeed without errors.

## Follow-ups (optional)

* `build-index --tile-size <N>` and `build-mosaic --tile-size <N>` to scope to a specific grid size.
* Add tests for store methods and grid lifecycle.
